### PR TITLE
Bump Paperclip Gem Verison 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'commontator', '~> 5.1.0'
 gem 'sdoc', '~> 1.0.0', group: :doc
 
 # Paperclip for attachments
-gem 'paperclip', '~> 4.3'
+gem 'paperclip'
 # Imagemagick for perceptual diffs
 gem 'rmagick'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,8 +80,6 @@ GEM
       nokogiri (~> 1.8)
     chronic (0.10.2)
     climate_control (0.2.0)
-    cocaine (0.5.8)
-      climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -148,7 +146,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mimemagic (0.3.0)
+    mimemagic (0.3.2)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -185,12 +183,12 @@ GEM
     nokogiri (1.8.2-x86-mingw32)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
-    paperclip (4.3.7)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
-      cocaine (~> 0.5.5)
+    paperclip (6.0.0)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
       mime-types
-      mimemagic (= 0.3.0)
+      mimemagic (~> 0.3.0)
+      terrapin (~> 0.6.0)
     pg (0.21.0)
     pg (0.21.0-x64-mingw32)
     pg (0.21.0-x86-mingw32)
@@ -300,6 +298,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    terrapin (0.6.0)
+      climate_control (>= 0.0.3, < 1.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     thread_safe (0.3.6-java)
@@ -374,7 +374,7 @@ DEPENDENCIES
   minitest-reporters (~> 1.1.14)
   multipart-post
   net-ldap
-  paperclip (~> 4.3)
+  paperclip
   pg
   puma (~> 3.0)
   rails (~> 5.1.4)


### PR DESCRIPTION
Paperclip ruby gem version 3.1.4 and later suffers from a Server-Side Request Forgery (SSRF) vulnerability. Bumping to 6.0 to uptake fix.