### PR TITLE
Make postgres host configurable

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -13,7 +13,7 @@ production: &production
   pool: <%= ENV["DB_POOL"] || ENV['RAILS_MAX_THREADS'] || 20 %>
   timeout: 5000
   host: <%= ENV['POSTGRES_HOST'] || postgres %>
-  port: 5432
+  port: <%= ENV['POSTGRES_PORT'] || 5432 %>
   username: <%= ENV['POSTGRES_USER'] %>
   password: <%= ENV['POSTGRES_PASSWORD'] %>
   encoding: utf8

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,7 +12,7 @@ production: &production
   adapter: postgresql
   pool: <%= ENV["DB_POOL"] || ENV['RAILS_MAX_THREADS'] || 20 %>
   timeout: 5000
-  host: <%= ENV['POSTGRES_HOST'] || postgres %>
+  host: <%= ENV['POSTGRES_HOST'] || 'postgres' %>
   port: <%= ENV['POSTGRES_PORT'] || 5432 %>
   username: <%= ENV['POSTGRES_USER'] %>
   password: <%= ENV['POSTGRES_PASSWORD'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,7 +12,7 @@ production: &production
   adapter: postgresql
   pool: <%= ENV["DB_POOL"] || ENV['RAILS_MAX_THREADS'] || 20 %>
   timeout: 5000
-  host: postgres
+  host: <%= ENV['POSTGRES_HOST'] || postgres %>
   port: 5432
   username: <%= ENV['POSTGRES_USER'] %>
   password: <%= ENV['POSTGRES_PASSWORD'] %>

--- a/vizzy/README.md
+++ b/vizzy/README.md
@@ -2,10 +2,10 @@
 
 This helm chart has a top level Vizzy chart, with a Postgresql chart defined as a dependency. When deploying the chart, be sure to specify a username, password, and database name for the postgresql chart.
 
-First pick a username and password for the database and create a kubernetes secret:
+First pick a username and password for the database and create a kubernetes secret, be sure to include the host:
 
 ```bash
-kubectl create secret generic vizzy-postgres-secret --from-literal=username=postgres --from-literal=password=********
+kubectl create secret generic vizzy-postgres-secret --from-literal=host=postgres --from-literal=username=postgres --from-literal=password=********
 ```
 
 If you haven't setup the server with credentials follow the [setup](https://github.com/Workday/vizzy#setup) section on the readme.

--- a/vizzy/README.md
+++ b/vizzy/README.md
@@ -2,10 +2,10 @@
 
 This helm chart has a top level Vizzy chart, with a Postgresql chart defined as a dependency. When deploying the chart, be sure to specify a username, password, and database name for the postgresql chart.
 
-First pick a username and password for the database and create a kubernetes secret, be sure to include the host:
+First pick a username and password for the database and create a kubernetes secret. Be sure to include the host and post:
 
 ```bash
-kubectl create secret generic vizzy-postgres-secret --from-literal=host=postgres --from-literal=username=postgres --from-literal=password=********
+kubectl create secret generic vizzy-postgres-secret --from-literal=host=postgres --from-literal=port=5432 --from-literal=username=postgres --from-literal=password=********
 ```
 
 If you haven't setup the server with credentials follow the [setup](https://github.com/Workday/vizzy#setup) section on the readme.

--- a/vizzy/templates/deployment.yaml
+++ b/vizzy/templates/deployment.yaml
@@ -44,6 +44,11 @@ spec:
             secretKeyRef:
               name: vizzy-postgres-secret
               key: host
+        - name: POSTGRES_PORT
+            valueFrom:
+              secretKeyRef:
+                name: vizzy-postgres-secret
+                key: port
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:

--- a/vizzy/templates/deployment.yaml
+++ b/vizzy/templates/deployment.yaml
@@ -39,6 +39,11 @@ spec:
           value: {{ .Values.env.vizzyUri.value }}
         - name: {{ .Values.env.railsEnv.name }}
           value: {{ .Values.env.railsEnv.value }}
+        - name: POSTGRES_HOST
+          valueFrom:
+            secretKeyRef:
+              name: vizzy-postgres-secret
+              key: host
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
You can now specify the Postgres host through the Postgres Kubernetes secret. If one is not specified, it will use the default `postgres`.