### PR TITLE
remove file limits for ImageMagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,6 @@ RUN rake assets:precompile
 
 EXPOSE 3000
 CMD ["rails", "server", "-b", "0.0.0.0"]
+
+# remove file limits for ImageMagick for builds that calculate lots of diffs
+RUN rm /etc/ImageMagick-6/policy.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,8 @@ COPY . /app
 # add encription key to decode secrets
 ARG RAILS_MASTER_KEY
 
-RUN rake assets:precompile
+# precompile rails assets and remove file limits for ImageMagick for builds that calculate lots of diffs
+RUN rake assets:precompile && rm -f /etc/ImageMagick-6/policy.xml
 
 EXPOSE 3000
 CMD ["rails", "server", "-b", "0.0.0.0"]
-
-# remove file limits for ImageMagick for builds that calculate lots of diffs
-RUN rm /etc/ImageMagick-6/policy.xml


### PR DESCRIPTION
About 1/3 Vizzy builds were not committing -- failed to finish creating all the diffs. Stepping through the logs I found a silent error that wasn’t reported to Bugsnag (Vizzy’s Fabric). This was the error that caused the background job to exit:

```
Error performing BuildBackgroundCommitJob (Job ID: d770c466-6868-4b89-a7f4-abe8f3dc9bf9) from Async(default) in 32961.12ms: Magick::ImageMagickError (cache resources exhausted `/app/public/visual_images/test_images/images/000/377/065/original/testGeneralHomepageWithTwoPercentCards_2x.png' @ error/cache.c/OpenPixelCache/3945)
```

Upon researching this error I found that there is a configuration file for ImageMagick (the tool that we use for creating diffs) that sets limits for memory, map, and disk resources. Specifically, the policy that caused the issues was MAGICK_FILE_LIMIT. It sets the maximum number of open pixel cache files. When this limit is exceeded, it kills the process to preserve the overall impact ImageMagick has on the system.

This is why Vizzy was only failing on builds with lots of diffs. Because there haven’t been new updates to Vizzy, I was curious how this changed. Ruby on Rails projects defines their dependencies in a Gemfile and a Gemfile.lock file which stores the version of each of the dependencies so you only get newer versions when you explicitly upgrade them. However, ImageMagick is not installed via Gemfile, it is installed in our Dockerfile, so when I built the image again, it pulled in the new configuration files.

The _fix_ was to *not* set limits as we did before - remove the `policy.xml` file in the `Dockerfile`. But after some research and data collection, we could set these limits accurately. I will also look into installing a specific version of ImageMagick to prevent this in the future.