### PR TITLE
Fix directory when pushing docker image for master branch on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ script:
 - docker-compose --version
 - docker-compose run -e RAILS_MASTER_KEY=$RAILS_MASTER_KEY app rake db:create db:migrate
 - docker-compose run -e RAILS_MASTER_KEY=$RAILS_MASTER_KEY app rake test
-- cd vizzy
-- helm lint
+- helm lint vizzy
 before_install:
 - openssl aes-256-cbc -K $encrypted_fb8ebefd631f_key -iv $encrypted_fb8ebefd631f_iv
   -in secrets.yml.enc -out config/secrets.yml.enc -d


### PR DESCRIPTION
After a PR merge, Travis CI builds and pushes the docker image to dockerhub. Didn't catch this earlier as the PR build doesn't push to dockerhub. 