### PR TITLE
increase the client_max_body_size for http connection for nginx to 100mb

### DIFF
--- a/vizzy/templates/ingress.yaml
+++ b/vizzy/templates/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
     "kubernetes.io/ingress.class": nginx
+    "nginx.ingress.kubernetes.io/proxy-body-size": "100m"
   name: {{ .Chart.Name }}
 spec:
   rules:

--- a/vizzy/templates/ingress.yaml
+++ b/vizzy/templates/ingress.yaml
@@ -4,8 +4,8 @@ kind: Ingress
 metadata:
   annotations:
     "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
+    "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.proxyBodySize }}
     "kubernetes.io/ingress.class": nginx
-    "nginx.ingress.kubernetes.io/proxy-body-size": "100m"
   name: {{ .Chart.Name }}
 spec:
   rules:

--- a/vizzy/values.yaml
+++ b/vizzy/values.yaml
@@ -43,3 +43,6 @@ postgresql:
   enabled: true
 
 secrets:
+
+ingress:
+  proxyBodySize: 100m


### PR DESCRIPTION
Need this to increase max-body-size for nginx over http/s to be greater than default 1mb.