### PR TITLE
Remove image pull secret from Helm chart

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,3 +7,4 @@ John Welsh
 Neha Saha
 Scott Bishop
 Stephen Marquis
+Kenny Ko

--- a/vizzy/README.md
+++ b/vizzy/README.md
@@ -15,7 +15,7 @@ kubectl create secret generic vizzy-postgres-secret \
 ```
 
 If you haven't setup the server with credentials follow the [setup](https://github.com/Workday/vizzy#setup) section on the readme.
- 
+
 After completing that, add another kubernetes secret for the rails master key that was generated and placed into `secrets.yml.key`. *Do not check in the encryption key into the repository,*
 
 ```bash
@@ -27,14 +27,8 @@ Then you can deploy the helm chart, overriding any [values](https://github.com/W
 ```bash
 helm install . \
     --set image.repository=scottcbishop/vizzy \
-    --set image.tag=3.1.1 \
-    --set image.pullSecret=myregistrykey \
+    --set image.tag=v3.1.1 \
     --set env.vizzyUri.value=vizzy.com \
     --set service.type=LoadBalancer \
-    --set replicaCount=1 \
-    --set postgresql.postgresUser=postgres \
-    --set postgresql.postgresPassword=******** \
-    --set postgresql.postgresDatabase=vizzy
+    --set replicaCount=1
  ```
- 
-    

--- a/vizzy/README.md
+++ b/vizzy/README.md
@@ -28,7 +28,11 @@ Then you can deploy the helm chart, overriding any [values](https://github.com/W
 helm install . \
     --set image.repository=scottcbishop/vizzy \
     --set image.tag=v3.1.1 \
+    --set image.pullSecret=myregistrykey \
     --set env.vizzyUri.value=vizzy.com \
     --set service.type=LoadBalancer \
-    --set replicaCount=1
+    --set replicaCount=1 \
+    --set postgresql.postgresUser=postgres \
+    --set postgresql.postgresPassword=******** \
+    --set postgresql.postgresDatabase=vizzy
  ```

--- a/vizzy/templates/deployment.yaml
+++ b/vizzy/templates/deployment.yaml
@@ -82,5 +82,7 @@ spec:
       - name: {{ .Values.volumes.name }}
         persistentVolumeClaim:
           claimName: {{ .Values.volumes.claimName }}
+{{- if .Values.image.pullSecret }}
       imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
+{{- end }}

--- a/vizzy/values.yaml
+++ b/vizzy/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 5
 image:
   repository: scottcbishop/vizzy
-  tag: v3.1.1
-  pullSecret: dockerhub.com
+  tag: latest
+  pullSecret: ""
   pullPolicy: Always
 
 volumeMounts:
@@ -44,4 +44,3 @@ postgresql:
   enabled: true
 
 secrets:
-


### PR DESCRIPTION
Removing the default image pull secret to allow use of the pull secret located in the default service account