### PR TITLE
Update puma version, previous version was yanked from rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.3.7'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.6.2'
 # Use Puma as the app server
-gem 'puma', '~> 3.0'
+gem 'puma', '~> 3.12.4'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0.7'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,8 +193,8 @@ GEM
     pg (0.21.0-x64-mingw32)
     pg (0.21.0-x86-mingw32)
     public_suffix (3.0.2)
-    puma (3.10.0)
-    puma (3.10.0-java)
+    puma (3.12.4)
+    puma (3.12.4-java)
     rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -379,7 +379,7 @@ DEPENDENCIES
   net-ldap
   paperclip
   pg
-  puma (~> 3.0)
+  puma (~> 3.12.4)
   rails (~> 5.1.6.2)
   rails-controller-testing
   rails_12factor
@@ -403,4 +403,4 @@ RUBY VERSION
    ruby 2.3.7p456
 
 BUNDLED WITH
-   1.16.1
+   2.0.2


### PR DESCRIPTION
- TravisCI was failing due to a version that was removed from rubygems.org